### PR TITLE
Correctly set check mark after accepting a new permission

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -71,9 +71,6 @@ async function togglePermission(tab: chrome.tabs.Tab, toggle: boolean): Promise<
 
 	const userAccepted = await chromeP.permissions.request(permissionData);
 	if (!userAccepted) {
-		chrome.contextMenus.update(contextMenuId, {
-			checked: false,
-		});
 		return;
 	}
 
@@ -117,7 +114,7 @@ async function handleClick(
 
 		throw error;
 	} finally {
-		void updateItem();
+		void updateItem(tab?.id ? await getTabUrl(tab?.id) : '');
 	}
 }
 


### PR DESCRIPTION
When the user requests the extension to be given access to the site and confirms this in the consequent browser dialog, the context menu item wasn't being immediately changed to checked.

We can fix this by ensuring that the `updateItem()` function which is responsible for updating the checkmark is called with the correct URL for the tab in question, so that it can detect whether the permission is now granted to the site and update the context menu item accordingly.

Note that the browser will automatically enable the checkmark simply by virtue of the context menu item having been clicked.  So if the user denies access in the dialog (despite previously requesting it to be given via a user-initiated "gesture", which is the only way the `chrome.permissions` API allows access to be given), then `chrome.contextMenus.update()` needs to be called to reverse that enabling of the checkmark.  However by calling `updateItem()` within the `finally` block with the correct tab URL, we can ensure the checkmark is always correctly set regardless of what happened.

Fixes #29.