### PR TITLE
Rename to `webext-permission-toggle`

### DIFF
--- a/demo/background.js
+++ b/demo/background.js
@@ -1,9 +1,9 @@
 import chromeP from 'webext-polyfill-kinda';
-import addDomainPermissionToggle from 'webext-domain-permission-toggle';
+import addHostPermissionToggle from 'webext-host-permission-toggle';
 
 console.log('Extension ready. Reload any tab to see the logs.');
 
-addDomainPermissionToggle();
+addHostPermissionToggle();
 
 chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
 	if (!tab.url) {

--- a/demo/background.js
+++ b/demo/background.js
@@ -1,9 +1,9 @@
 import chromeP from 'webext-polyfill-kinda';
-import addHostPermissionToggle from 'webext-host-permission-toggle';
+import addPermissionToggle from 'webext-permission-toggle';
 
 console.log('Extension ready. Reload any tab to see the logs.');
 
-addHostPermissionToggle();
+addPermissionToggle();
 
 chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
 	if (!tab.url) {

--- a/demo/mv2/manifest.json
+++ b/demo/mv2/manifest.json
@@ -1,5 +1,5 @@
 {
-	"name": "webext-host-permission-toggle",
+	"name": "webext-permission-toggle",
 	"version": "0.0.0",
 	"manifest_version": 2,
 	"permissions": [

--- a/demo/mv2/manifest.json
+++ b/demo/mv2/manifest.json
@@ -1,5 +1,5 @@
 {
-	"name": "webext-domain-permission-toggle",
+	"name": "webext-host-permission-toggle",
 	"version": "0.0.0",
 	"manifest_version": 2,
 	"permissions": [

--- a/demo/mv3/manifest.json
+++ b/demo/mv3/manifest.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://json.schemastore.org/chrome-manifest",
-	"name": "webext-domain-permission-toggle",
+	"name": "webext-host-permission-toggle",
 	"version": "0.0.0",
 	"manifest_version": 3,
 	"permissions": [

--- a/demo/mv3/manifest.json
+++ b/demo/mv3/manifest.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://json.schemastore.org/chrome-manifest",
-	"name": "webext-host-permission-toggle",
+	"name": "webext-permission-toggle",
 	"version": "0.0.0",
 	"manifest_version": 3,
 	"permissions": [

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,6 +1,6 @@
 {
 	"type": "module",
 	"alias": {
-		"webext-host-permission-toggle": "../index.ts"
+		"webext-permission-toggle": "../index.ts"
 	}
 }

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,6 +1,6 @@
 {
 	"type": "module",
 	"alias": {
-		"webext-domain-permission-toggle": "../index.ts"
+		"webext-host-permission-toggle": "../index.ts"
 	}
 }

--- a/demo/readme.md
+++ b/demo/readme.md
@@ -1,4 +1,4 @@
-Demo/test extension for `webext-domain-permission-toggle`
+Demo/test extension for `webext-host-permission-toggle`
 
 Run these 3 commands simultaneusly to manually test the module:
 

--- a/demo/readme.md
+++ b/demo/readme.md
@@ -1,4 +1,4 @@
-Demo/test extension for `webext-host-permission-toggle`
+Demo/test extension for `webext-permission-toggle`
 
 Run these 3 commands simultaneusly to manually test the module:
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -55,7 +55,7 @@
 		</div>
 		<footer>
 			<p>
-				Feature added with the <a href="https://github.com/fregante/webext-domain-permission-toggle">webext-domain-permission-toggle</a> module by <a href="https://fregante.com">@fregante</a>. Guide icons by <a href="https://chromium.googlesource.com/chromium/src/+/lkgr/ui/webui/resources/images">Google</a> and <a
+				Feature added with the <a href="https://github.com/fregante/webext-host-permission-toggle">webext-host-permission-toggle</a> module by <a href="https://fregante.com">@fregante</a>. Guide icons by <a href="https://chromium.googlesource.com/chromium/src/+/lkgr/ui/webui/resources/images">Google</a> and <a
 					href="https://www.flaticon.com/authors/pongsakornred"
 					title="pongsakornRed"
 					rel="nofollow">pongsakornRed</a>. You can also <a href="#customize">customize this page</a> for your extension if it uses the same module.

--- a/docs/index.html
+++ b/docs/index.html
@@ -55,7 +55,7 @@
 		</div>
 		<footer>
 			<p>
-				Feature added with the <a href="https://github.com/fregante/webext-host-permission-toggle">webext-host-permission-toggle</a> module by <a href="https://fregante.com">@fregante</a>. Guide icons by <a href="https://chromium.googlesource.com/chromium/src/+/lkgr/ui/webui/resources/images">Google</a> and <a
+				Feature added with the <a href="https://github.com/fregante/webext-permission-toggle">webext-permission-toggle</a> module by <a href="https://fregante.com">@fregante</a>. Guide icons by <a href="https://chromium.googlesource.com/chromium/src/+/lkgr/ui/webui/resources/images">Google</a> and <a
 					href="https://www.flaticon.com/authors/pongsakornred"
 					title="pongsakornRed"
 					rel="nofollow">pongsakornRed</a>. You can also <a href="#customize">customize this page</a> for your extension if it uses the same module.

--- a/index.ts
+++ b/index.ts
@@ -4,7 +4,7 @@ import {isUrlPermittedByManifest} from 'webext-permissions';
 import {getTabUrl} from 'webext-tools';
 import {executeFunction} from 'webext-content-scripts';
 
-const contextMenuId = 'webext-host-permission-toggle:add-permission';
+const contextMenuId = 'webext-permission-toggle:add-permission';
 let globalOptions: Options;
 
 type Options = {
@@ -128,19 +128,19 @@ async function handleClick(
  *
  * @param options {Options}
  */
-export default function addHostPermissionToggle(options?: Options): void {
+export default function addPermissionToggle(options?: Options): void {
 	if (!isBackground()) {
-		throw new Error('webext-host-permission-toggle can only be called from a background page');
+		throw new Error('webext-permission-toggle can only be called from a background page');
 	}
 
 	if (globalOptions) {
-		throw new Error('webext-host-permission-toggle can only be initialized once');
+		throw new Error('webext-permission-toggle can only be initialized once');
 	}
 
 	const manifest = chrome.runtime.getManifest();
 
 	if (!manifest.permissions?.includes('contextMenus')) {
-		throw new Error('webext-host-permission-toggle requires the `contextMenus` permission');
+		throw new Error('webext-permission-toggle requires the `contextMenus` permission');
 	}
 
 	if (!chrome.contextMenus) {
@@ -164,7 +164,7 @@ export default function addHostPermissionToggle(options?: Options): void {
 	].filter((permission: string) => permission === '<all_urls>' || permission.includes('*'));
 
 	if (optionalHosts.length === 0) {
-		throw new TypeError('webext-host-permission-toggle requires some wildcard hosts to be specified in `optional_permissions` or `optional_host_permissions` (MV3)');
+		throw new TypeError('webext-permission-toggle requires some wildcard hosts to be specified in `optional_permissions` or `optional_host_permissions` (MV3)');
 	}
 
 	// Remove any existing context menu item and silence any error

--- a/index.ts
+++ b/index.ts
@@ -4,7 +4,7 @@ import {isUrlPermittedByManifest} from 'webext-permissions';
 import {getTabUrl} from 'webext-tools';
 import {executeFunction} from 'webext-content-scripts';
 
-const contextMenuId = 'webext-domain-permission-toggle:add-permission';
+const contextMenuId = 'webext-host-permission-toggle:add-permission';
 let globalOptions: Options;
 
 type Options = {
@@ -128,19 +128,19 @@ async function handleClick(
  *
  * @param options {Options}
  */
-export default function addDomainPermissionToggle(options?: Options): void {
+export default function addHostPermissionToggle(options?: Options): void {
 	if (!isBackground()) {
-		throw new Error('webext-domain-permission-toggle can only be called from a background page');
+		throw new Error('webext-host-permission-toggle can only be called from a background page');
 	}
 
 	if (globalOptions) {
-		throw new Error('webext-domain-permission-toggle can only be initialized once');
+		throw new Error('webext-host-permission-toggle can only be initialized once');
 	}
 
 	const manifest = chrome.runtime.getManifest();
 
 	if (!manifest.permissions?.includes('contextMenus')) {
-		throw new Error('webext-domain-permission-toggle requires the `contextMenus` permission');
+		throw new Error('webext-host-permission-toggle requires the `contextMenus` permission');
 	}
 
 	if (!chrome.contextMenus) {
@@ -164,7 +164,7 @@ export default function addDomainPermissionToggle(options?: Options): void {
 	].filter((permission: string) => permission === '<all_urls>' || permission.includes('*'));
 
 	if (optionalHosts.length === 0) {
-		throw new TypeError('webext-domain-permission-toggle requires some wildcard hosts to be specified in `optional_permissions` or `optional_host_permissions` (MV3)');
+		throw new TypeError('webext-host-permission-toggle requires some wildcard hosts to be specified in `optional_permissions` or `optional_host_permissions` (MV3)');
 	}
 
 	// Remove any existing context menu item and silence any error

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "webext-permission-toggle",
-	"version": "4.1.0",
+	"version": "5.0.0-0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "webext-permission-toggle",
-			"version": "4.1.0",
+			"version": "5.0.0-0",
 			"license": "MIT",
 			"dependencies": {
 				"webext-content-scripts": "^2.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "webext-host-permission-toggle",
+	"name": "webext-permission-toggle",
 	"version": "4.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "webext-host-permission-toggle",
+			"name": "webext-permission-toggle",
 			"version": "4.1.0",
 			"license": "MIT",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "webext-domain-permission-toggle",
+	"name": "webext-host-permission-toggle",
 	"version": "4.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "webext-domain-permission-toggle",
+			"name": "webext-host-permission-toggle",
 			"version": "4.1.0",
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "webext-permission-toggle",
-	"version": "4.1.0",
+	"version": "5.0.0-0",
 	"description": "Browser-action context menu to request permission for the current tab. Chrome, Firefox, Safari.",
 	"keywords": [
 		"browser",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "webext-domain-permission-toggle",
+	"name": "webext-host-permission-toggle",
 	"version": "4.1.0",
 	"description": "Browser-action context menu to request permission for the current tab. Chrome, Firefox, Safari.",
 	"keywords": [
@@ -14,7 +14,7 @@
 		"ui",
 		"webextension"
 	],
-	"repository": "fregante/webext-domain-permission-toggle",
+	"repository": "fregante/webext-host-permission-toggle",
 	"funding": "https://github.com/sponsors/fregante",
 	"license": "MIT",
 	"author": "Federico Brigante <me@fregante.com> (https://fregante.com)",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "webext-host-permission-toggle",
+	"name": "webext-permission-toggle",
 	"version": "4.1.0",
 	"description": "Browser-action context menu to request permission for the current tab. Chrome, Firefox, Safari.",
 	"keywords": [
@@ -14,7 +14,7 @@
 		"ui",
 		"webextension"
 	],
-	"repository": "fregante/webext-host-permission-toggle",
+	"repository": "fregante/webext-permission-toggle",
 	"funding": "https://github.com/sponsors/fregante",
 	"license": "MIT",
 	"author": "Federico Brigante <me@fregante.com> (https://fregante.com)",

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# webext-host-permission-toggle [![npm version](https://img.shields.io/npm/v/webext-host-permission-toggle.svg)](https://www.npmjs.com/package/webext-host-permission-toggle)
+# webext-permission-toggle [![npm version](https://img.shields.io/npm/v/webext-permission-toggle.svg)](https://www.npmjs.com/package/webext-permission-toggle)
 
 <img width="331" alt="Context menu" src="https://user-images.githubusercontent.com/1402241/32874388-e0c64150-cacc-11e7-9a50-eae3727fd3c2.png" align="right">
 
@@ -9,27 +9,27 @@
 
 Works great when paired with [webext-dynamic-content-scripts](https://github.com/fregante/webext-dynamic-content-scripts/blob/master/how-to-add-github-enterprise-support-to-web-extensions.md) if you want to also inject content scripts on the new hosts.
 
-This repository even includes a [customizable guide](https://fregante.github.io/webext-host-permission-toggle/) to tell your users how to use it. At the bottom of that page, you'll find a link that lets you customize it with your extension’s name and icon. You can link your users to it directly, it's a permalink.
+This repository even includes a [customizable guide](https://fregante.github.io/webext-permission-toggle/) to tell your users how to use it. At the bottom of that page, you'll find a link that lets you customize it with your extension’s name and icon. You can link your users to it directly, it's a permalink.
 
 ## Install
 
-You can download the [standalone bundle](https://bundle.fregante.com/?pkg=webext-host-permission-toggle&global=addHostPermissionToggle) and include it in your `manifest.json`.
+You can download the [standalone bundle](https://bundle.fregante.com/?pkg=webext-permission-toggle&global=addPermissionToggle) and include it in your `manifest.json`.
 
 Or use `npm`:
 
 ```sh
-npm install webext-host-permission-toggle
+npm install webext-permission-toggle
 ```
 
 ```js
-import addHostPermissionToggle from 'webext-host-permission-toggle';
+import addPermissionToggle from 'webext-permission-toggle';
 ```
 
 ## Usage
 
 ```js
 // In background.js
-addHostPermissionToggle();
+addPermissionToggle();
 ```
 
 ### manifest.json v3
@@ -37,7 +37,7 @@ addHostPermissionToggle();
 ```js
 // example background.worker.js
 navigator.importScripts(
-	"webext-host-permission-toggle.js"
+	"webext-permission-toggle.js"
 )
 ```
 ```js
@@ -77,7 +77,7 @@ navigator.importScripts(
 	],
 	"background": {
 		"scripts": [
-			"webext-host-permission-toggle.js",
+			"webext-permission-toggle.js",
 			"background.js"
 		]
 	}
@@ -86,7 +86,7 @@ navigator.importScripts(
 
 ## API
 
-### addHostPermissionToggle([options])
+### addPermissionToggle([options])
 
 <img width="331" alt="Context menu" src="https://user-images.githubusercontent.com/1402241/32874388-e0c64150-cacc-11e7-9a50-eae3727fd3c2.png" align="right">
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# webext-domain-permission-toggle [![npm version](https://img.shields.io/npm/v/webext-domain-permission-toggle.svg)](https://www.npmjs.com/package/webext-domain-permission-toggle)
+# webext-host-permission-toggle [![npm version](https://img.shields.io/npm/v/webext-host-permission-toggle.svg)](https://www.npmjs.com/package/webext-host-permission-toggle)
 
 <img width="331" alt="Context menu" src="https://user-images.githubusercontent.com/1402241/32874388-e0c64150-cacc-11e7-9a50-eae3727fd3c2.png" align="right">
 
@@ -7,29 +7,29 @@
 - Browsers: Chrome, Firefox, and Safari
 - Manifest: v2 and v3
 
-Works great when paired with [webext-dynamic-content-scripts](https://github.com/fregante/webext-dynamic-content-scripts/blob/master/how-to-add-github-enterprise-support-to-web-extensions.md) if you want to also inject content scripts on the new domains.
+Works great when paired with [webext-dynamic-content-scripts](https://github.com/fregante/webext-dynamic-content-scripts/blob/master/how-to-add-github-enterprise-support-to-web-extensions.md) if you want to also inject content scripts on the new hosts.
 
-This repository even includes a [customizable guide](https://fregante.github.io/webext-domain-permission-toggle/) to tell your users how to use it. At the bottom of that page, you'll find a link that lets you customize it with your extension’s name and icon. You can link your users to it directly, it's a permalink.
+This repository even includes a [customizable guide](https://fregante.github.io/webext-host-permission-toggle/) to tell your users how to use it. At the bottom of that page, you'll find a link that lets you customize it with your extension’s name and icon. You can link your users to it directly, it's a permalink.
 
 ## Install
 
-You can download the [standalone bundle](https://bundle.fregante.com/?pkg=webext-domain-permission-toggle&global=addDomainPermissionToggle) and include it in your `manifest.json`.
+You can download the [standalone bundle](https://bundle.fregante.com/?pkg=webext-host-permission-toggle&global=addHostPermissionToggle) and include it in your `manifest.json`.
 
 Or use `npm`:
 
 ```sh
-npm install webext-domain-permission-toggle
+npm install webext-host-permission-toggle
 ```
 
 ```js
-import addDomainPermissionToggle from 'webext-domain-permission-toggle';
+import addHostPermissionToggle from 'webext-host-permission-toggle';
 ```
 
 ## Usage
 
 ```js
 // In background.js
-addDomainPermissionToggle();
+addHostPermissionToggle();
 ```
 
 ### manifest.json v3
@@ -37,7 +37,7 @@ addDomainPermissionToggle();
 ```js
 // example background.worker.js
 navigator.importScripts(
-	"webext-domain-permission-toggle.js"
+	"webext-host-permission-toggle.js"
 )
 ```
 ```js
@@ -77,7 +77,7 @@ navigator.importScripts(
 	],
 	"background": {
 		"scripts": [
-			"webext-domain-permission-toggle.js",
+			"webext-host-permission-toggle.js",
 			"background.js"
 		]
 	}
@@ -86,7 +86,7 @@ navigator.importScripts(
 
 ## API
 
-### addDomainPermissionToggle([options])
+### addHostPermissionToggle([options])
 
 <img width="331" alt="Context menu" src="https://user-images.githubusercontent.com/1402241/32874388-e0c64150-cacc-11e7-9a50-eae3727fd3c2.png" align="right">
 
@@ -116,7 +116,7 @@ If `true` or `string`, when the user accepts the new permission, they will be as
 
 ## Related
 
-- [webext-dynamic-content-scripts](https://github.com/fregante/webext-dynamic-content-scripts) - Automatically registers your content_scripts on domains added via permission.request
+- [webext-dynamic-content-scripts](https://github.com/fregante/webext-dynamic-content-scripts) - Automatically registers your content_scripts on hosts added via `permission.request()`
 - [webext-additional-permissions](https://github.com/fregante/webext-additional-permissions) - Get any optional permissions that users have granted you.
 - [webext-options-sync](https://github.com/fregante/webext-options-sync) - Helps you manage and autosave your extension's options. Chrome and Firefox.
 - [Awesome-WebExtensions](https://github.com/fregante/Awesome-WebExtensions) - A curated list of awesome resources for WebExtensions development.


### PR DESCRIPTION
I'll merge this once I'm ready for the rename. v5 will be published there.

"domain" makes sense for users, but extensions always call them "hosts".

I left "domain" for the user UI (because "host" doesn't make sense) but I call them "host" in the code.