### PR TITLE
Remove a broader permission if granted

### DIFF
--- a/demo/background.js
+++ b/demo/background.js
@@ -16,3 +16,6 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
 });
 
 (chrome.action ?? chrome.browserAction).onClicked.addListener(async () => chromeP.permissions.request({origins: ['*://*/*']}));
+
+chrome.permissions.onAdded.addListener(permissions => console.log('Permissions added:', permissions));
+chrome.permissions.onRemoved.addListener(permissions => console.log('Permissions removed:', permissions));

--- a/demo/background.js
+++ b/demo/background.js
@@ -14,3 +14,5 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
 	const why = await chromeP.permissions.contains({origins: [tab.url]}) ? 'granted' : 'just because of activeTab';
 	console.log('Access to tab', tabId, tab.url, why);
 });
+
+(chrome.action ?? chrome.browserAction).onClicked.addListener(async () => chromeP.permissions.request({origins: ['*://*/*']}));

--- a/index.ts
+++ b/index.ts
@@ -100,14 +100,6 @@ async function updateItem(url?: string): Promise<void> {
  * @returns Whether the permission exists after the request/removal
  */
 async function setPermission(url: string, request: boolean): Promise<boolean> {
-	const {origins = []} = await chromeP.permissions.getAll();
-	const matchingPatterns = findMatchingPatterns(url, ...origins);
-	const current = matchingPatterns.length > 0;
-	if (current === request) {
-		// No change required
-		return request;
-	}
-
 	const permissionData = {
 		origins: [
 			new URL(url).origin + '/*',
@@ -120,6 +112,8 @@ async function setPermission(url: string, request: boolean): Promise<boolean> {
 		// The user, browser or extension might have granted permissions broader than the exact origin we find here.
 		// https://github.com/fregante/webext-permission-toggle/issues/37
 		// This might also remove a `*://*/*` permission if granted, which might unexpected but "technically correct" since, after this successful removal, the extension will no longer have access to the current domain, as requested.
+		const {origins = []} = await chromeP.permissions.getAll();
+		const matchingPatterns = findMatchingPatterns(url, ...origins);
 		console.debug('Removing permissions:', ...matchingPatterns);
 		await chromeP.permissions.remove({
 			origins: matchingPatterns,

--- a/index.ts
+++ b/index.ts
@@ -82,6 +82,7 @@ async function updateItem(url?: string): Promise<void> {
 		updateItemRaw({
 			// Don't let the user remove a default permission.
 			// However, if they removed it via Chrome's UI, let them re-enable it with this toggle.
+			// https://github.com/fregante/webext-permission-toggle/pull/54
 			enabled: !isDefault || !hasPermission,
 			checked: hasPermission,
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"webext-alert": "^1.0.0",
 				"webext-content-scripts": "^2.6.1",
 				"webext-detect-page": "^5.0.1",
+				"webext-patterns": "^1.5.0",
 				"webext-permissions": "^3.1.3",
 				"webext-polyfill-kinda": "^1.0.2",
 				"webext-tools": "^1.2.5"
@@ -8702,9 +8703,10 @@
 			}
 		},
 		"node_modules/webext-patterns": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/webext-patterns/-/webext-patterns-1.4.0.tgz",
-			"integrity": "sha512-ntzTWnsRuus0hZdHlbjNUFSA9mZz+sYU37KxkU5Et5TggkxqMienQBeGP2At4TMzeXpUvC3fafCr2Oiy7YDsBw==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/webext-patterns/-/webext-patterns-1.5.0.tgz",
+			"integrity": "sha512-w4BnLNQVy1ldlc3BGTzDBm0vfqyDo5/YSd5UacgtcQsw23vANH+rX170tp6udvCVUyJJsFW4OUlmH2Gqfj742A==",
+			"license": "MIT",
 			"dependencies": {
 				"escape-string-regexp": "^5.0.0"
 			},

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 		"webext-alert": "^1.0.0",
 		"webext-content-scripts": "^2.6.1",
 		"webext-detect-page": "^5.0.1",
+		"webext-patterns": "^1.5.0",
 		"webext-permissions": "^3.1.3",
 		"webext-polyfill-kinda": "^1.0.2",
 		"webext-tools": "^1.2.5"


### PR DESCRIPTION
- Should fix https://github.com/fregante/webext-permission-toggle/issues/37
- Uses https://github.com/fregante/webext-patterns/pull/21

However… `Error: This function must be called during a user gesture`

Edit: fixed by moving the query only to the `.remove()` call, which doesn't have this restriction.