### PR TITLE
Update menu item when switching windows

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -128,6 +128,15 @@ async function handleTabActivated({tabId}: chrome.tabs.TabActiveInfo): Promise<v
 	void updateItem(await getTabUrl(tabId) ?? '');
 }
 
+async function handleWindowFocusChanged(windowId: number): Promise<void> {
+	const [tab] = await chromeP.tabs.query({
+		active: true,
+		windowId,
+	});
+
+	void updateItem(tab?.url);
+}
+
 async function handleClick(
 	{checked, menuItemId}: chrome.contextMenus.OnClickData,
 	tab?: chrome.tabs.Tab,
@@ -253,6 +262,7 @@ export default function addPermissionToggle(options?: Options): void {
 
 	chrome.contextMenus.onClicked.addListener(handleClick);
 	chrome.tabs.onActivated.addListener(handleTabActivated);
+	chrome.windows.onFocusChanged.addListener(handleWindowFocusChanged, {windowTypes: ['normal']});
 	chrome.tabs.onUpdated.addListener(async (tabId, {status}, {url, active}) => {
 		if (active && status === 'complete') {
 			void updateItem(url ?? await getTabUrl(tabId) ?? '');

--- a/index.ts
+++ b/index.ts
@@ -262,6 +262,8 @@ export default function addPermissionToggle(options?: Options): void {
 
 	chrome.contextMenus.onClicked.addListener(handleClick);
 	chrome.tabs.onActivated.addListener(handleTabActivated);
+	// Chrome won't fire `onFocusChanged` if the window is clicked when a context menu is open
+	// https://github.com/fregante/webext-permission-toggle/pull/60
 	chrome.windows.onFocusChanged.addListener(handleWindowFocusChanged, {windowTypes: ['normal']});
 	chrome.tabs.onUpdated.addListener(async (tabId, {status}, {url, active}) => {
 		if (active && status === 'complete') {


### PR DESCRIPTION
- Closes #59 

## Demo switching between manifest permission and new host

https://github.com/fregante/webext-permission-toggle/assets/1402241/df894020-b158-47c1-869b-45f1ae22b951


## Chrome bug: switching without closing the context menu 


https://github.com/fregante/webext-permission-toggle/assets/1402241/80bc35bd-d384-40a9-b4b0-3dd93ed00f8a

